### PR TITLE
Fix always exiting with 1

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -125,7 +125,11 @@ func (g *Generator) Run(ctx context.Context, database, shardPath string, groups 
 		errs = append(errs, e)
 	}
 
-	return errs
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
 }
 
 // seriesBatchSize specifies the number of series keys passed to the index.


### PR DESCRIPTION
Return nil for an empty ErrorList to avoid getting a non-nil error further up.